### PR TITLE
Update comments parser to allow code annotations

### DIFF
--- a/srlinux_lexer/parsers.py
+++ b/srlinux_lexer/parsers.py
@@ -14,9 +14,9 @@ srl_prompt = [
 ]
 
 comments = [
-    # comments in the CLI snippets `#`. https://regex101.com/r/dtR80f/1
+    # comments in the CLI snippets `#`. https://regex101.com/r/dtR80f/2
     (
-        r"^\s*#.*$",
+        r"(?:[^\n\w]+#.*$)|(?:^\s*#.*$)",
         Comment,
     ),
 ]


### PR DESCRIPTION
to allow for 
```
some text #(1)!
```
annotations used in mkdocs-material